### PR TITLE
Force cloudcannon-jekyll to run after other :lowest plugins

### DIFF
--- a/lib/cloudcannon-jekyll/generator.rb
+++ b/lib/cloudcannon-jekyll/generator.rb
@@ -7,11 +7,10 @@ require_relative "reader"
 module CloudCannonJekyll
   # Generates JSON files containing build config and build output details
   class Generator < Jekyll::Generator
-    
     # Override the Jekyll::Plugin spaceship to push our plugin to the very end
     priority :lowest
-    def self.<=>(other)
-      return 1
+    def self.<=>(*)
+      1
     end
 
     def generate(site)

--- a/lib/cloudcannon-jekyll/generator.rb
+++ b/lib/cloudcannon-jekyll/generator.rb
@@ -7,7 +7,12 @@ require_relative "reader"
 module CloudCannonJekyll
   # Generates JSON files containing build config and build output details
   class Generator < Jekyll::Generator
+    
+    # Override the Jekyll::Plugin spaceship to push our plugin to the very end
     priority :lowest
+    def self.<=>(other)
+      return 1
+    end
 
     def generate(site)
       @site = site


### PR DESCRIPTION
Adds a spaceship operator to `generator.rb` that should override the default spaceship operator in Jekyll's `plugin.rb` file. The only circumstance I can see where this would fail to sort this plugin last is if another plugin also overrides its spaceship method. I have tested this, and it goes back to an unstable last place sort, but it doesn't cause any error.

I have tested the change locally across a few test sites with varying sizes/complexity and haven't seen any errors crop up. It would be worth chucking it at a few more sites to be sure.

The following line will use the fix. There are no logs so you can't determine plugin order, but we can assume that a lack of errors is an 🆗
```
gem 'cloudcannon-jekyll', :git => 'https://github.com/bglw/cloudcannon-jekyll'
```